### PR TITLE
Improved emoji input, streamline passing user id from one immer to the next

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,6 +90,7 @@ app.route('/auth/login')
     const data = { name, domain, monetizationPointer, ...theme }
     if (req.session && req.session.handle) {
       Object.assign(data, parseHandle(req.session.handle))
+      delete req.session.handle
     }
     res.render('dist/login/login.html', data)
   })

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ const request = require('request-promise-native')
 const nunjucks = require('nunjucks')
 const passport = require('passport')
 const auth = require('./src/auth')
+const { parseHandle } = require('./src/utils')
 
 const {
   port,
@@ -87,6 +88,9 @@ app.options('*', cors())
 app.route('/auth/login')
   .get((req, res) => {
     const data = { name, domain, monetizationPointer, ...theme }
+    if (req.session && req.session.handle) {
+      Object.assign(data, parseHandle(req.session.handle))
+    }
     res.render('dist/login/login.html', data)
   })
   .post(passport.authenticate('local', {
@@ -119,6 +123,8 @@ async function registerActor (req, res, next) {
   } catch (err) { next(err) }
 }
 app.post('/auth/user', auth.validateNewUser, auth.logout, registerActor, auth.registration)
+// users are sent here from Hub to get access token, but it may interrupt with redirect
+// to login and further redirect to login at their home immer if they are remote
 app.get('/auth/authorize', auth.authorization)
 app.post('/auth/decision', auth.decision)
 // get actor from token

--- a/package-lock.json
+++ b/package-lock.json
@@ -4777,6 +4777,11 @@
         "unicode-trie": "^0.3.1"
       }
     },
+    "grapheme-splitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
+    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.1",
   "description": "ActivityPub server for the metaverse",
   "main": "index.js",
+  "engines" : { "node" : ">=12.16.2" },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev:server": "cross-env NODE_TLS_REJECT_UNAUTHORIZED=0 node index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "immers",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "ActivityPub server for the metaverse",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.2.1",
   "description": "ActivityPub server for the metaverse",
   "main": "index.js",
-  "engines" : { "node" : ">=12.16.2" },
+  "engines": {
+    "node": ">=12.16.2"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev:server": "cross-env NODE_TLS_REJECT_UNAUTHORIZED=0 node index.js",
@@ -46,6 +48,7 @@
     "emoji-mart": "^3.0.0",
     "express": "^4.17.1",
     "express-session": "^1.17.1",
+    "grapheme-splitter": "^1.0.4",
     "https-redirector": "^1.0.0",
     "mongodb": "^3.5.7",
     "nodemailer": "^6.4.6",

--- a/src/auth.js
+++ b/src/auth.js
@@ -243,8 +243,7 @@ async function checkImmer (req, res, next) {
       })
       await authdb.saveRemoteClient(immer, client)
     }
-    /* returnTo is /auth/authorize with client_id and
-     * redirect_uri for the destination immer + room id + optional user handle
+    /* returnTo is /auth/authorize with client_id and redirect_uri for the destination immer
      * so users are sent home to login and authorize the destination immer as a client,
      * then come back the same room on the desination with their token
      */

--- a/src/auth.js
+++ b/src/auth.js
@@ -244,7 +244,7 @@ async function checkImmer (req, res, next) {
       await authdb.saveRemoteClient(remoteDomain, client)
     }
     /* returnTo is /auth/authorize with client_id and
-     * redirect_uri for the destination immer + room id
+     * redirect_uri for the destination immer + room id + (optional) user handle
      * so users are sent home to login and authorize the destination immer as a client,
      * then come back the same room on the desination with their token
      */
@@ -253,7 +253,12 @@ async function checkImmer (req, res, next) {
 }
 
 function stashHandle (req, res, next) {
-  // save in session so we can pick it up in the ensureLoggedIn redirect
+  /* to save repeated handle entry, a hub can pass along the user's handle
+   * when linking between hubs (e.g. friends list links). Extract it from
+   * redirect_uri (hub link), store it in session for access during login
+   * redirect, and remove it from redirect_uri so it doesn't pollute the user's
+   * address bar after login
+   */
   if (req.query.redirect_uri && req.session) {
     const url = new URL(req.query.redirect_uri)
     const search = new URLSearchParams(url.search)

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,15 @@
+module.exports = {
+  parseHandle
+}
+
+const handleReg = /([^@[]+)[@[]([^\]]+)/
+
+function parseHandle (handle) {
+  const match = handleReg.exec(handle)
+  if (match && match.length === 3) {
+    return {
+      username: match[1],
+      immer: match[2]
+    }
+  }
+}

--- a/views/assets/immers.css
+++ b/views/assets/immers.css
@@ -41,6 +41,7 @@ h1 {
   right: 0;
   bottom: 0;
   padding: 5px;
+  z-index: 0;
 }
 
 .content {
@@ -51,22 +52,31 @@ h1 {
  justify-content: space-around;
 }
 
+.main-content {
+  z-index: 5;
+}
+
 .content form {
   margin: 20px;
   /* transition: all 1s; */
 }
 
 .form-item {
-  padding: 10px;
+  height: 40px;
+  padding: 5px 10px;
   display: flex;
   justify-content: space-between;
   align-items: center;
 }
 
 .form-item, .form-item label, .form-item input {
-  transition: all 0.5s ease-in;
-  height: 33px;
+  transition: all 0.5s ease-in-out;
   overflow: hidden;
+}
+
+.form-item input, .form-item label {
+  height: 35px;
+  margin: 1px;
 }
 
 .form-item label {
@@ -74,9 +84,9 @@ h1 {
 }
 
 .form-item input {
-  width: 399px;
+  width: 398px;
   padding-left: 5px;
-  margin-right: 9px;
+  margin-right: 10px;
 }
 
 .form-item input.with-feedback {
@@ -93,8 +103,9 @@ h1 {
 }
 
 .form-item input.handle {
-  width: 190px;
-  margin-right: 0;
+  width: 189px;
+  margin-right: 1px;
+  margin-left: 1px;
 }
 
 .form-item.emoji {
@@ -142,6 +153,24 @@ button[disabled] {
 
 .password-wrapper {
   scroll-margin: 30px;
+}
+
+.reveal-pass {
+  position: absolute;
+  top: 0;
+  width: 365px;
+  background-color: #FFFE;
+  margin: 3px 6px;
+}
+
+.reveal-pass .emoji-mart-emoji {
+  vertical-align: middle;
+}
+
+/* to make alignment easier */
+.handle-bracket {
+  display: inline-block;
+  width: 10px;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/views/assets/immers.css
+++ b/views/assets/immers.css
@@ -54,6 +54,8 @@ h1 {
 
 .main-content {
   z-index: 5;
+  min-width: 670px;
+  flex-shrink: 0;
 }
 
 .content form {
@@ -62,8 +64,8 @@ h1 {
 }
 
 .form-item {
-  height: 40px;
-  padding: 5px 10px;
+  height: 60px;
+  padding: 0;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -72,6 +74,7 @@ h1 {
 .form-item, .form-item label, .form-item input {
   transition: all 0.5s ease-in-out;
   overflow: hidden;
+  box-sizing: border-box;
 }
 
 .form-item input, .form-item label {
@@ -84,14 +87,14 @@ h1 {
 }
 
 .form-item input {
-  width: 398px;
+  width: 400px;
   padding-left: 5px;
   margin-right: 10px;
+  flex-shrink: 0;
 }
 
 .form-item input.with-feedback {
   padding-right: 30px;
-  width: 370px;
 }
 
 .form-item-feedback {
@@ -103,15 +106,14 @@ h1 {
 }
 
 .form-item input.handle {
-  width: 189px;
-  margin-right: 1px;
-  margin-left: 1px;
+  width: 195px;
+  margin-right: 0;
+  margin-left: 0;
 }
 
 .form-item.emoji {
   height: 430px;
   justify-content: center;
-  padding-top: 0;
 }
 
 .form-item.emoji.hidden {

--- a/views/components/HandleInput.js
+++ b/views/components/HandleInput.js
@@ -30,7 +30,7 @@ export default class HandleInput extends React.Component {
             title='Letters, numbers, &amp; dashes only, between 3 and 32 characters'
             value={this.state.username}
           />
-          [
+          <span className='handle-bracket'>[</span>
           <input
             onChange={this.handleInput}
             id='immer' className='aesthetic-windows-95-text-input handle'
@@ -40,7 +40,7 @@ export default class HandleInput extends React.Component {
             title='Valid domain name, including .'
             value={this.state.immer} disabled={this.props.lockImmer}
           />
-          ]
+          <span>]</span>
         </div>
       </div>
     )

--- a/views/components/HandleInput.js
+++ b/views/components/HandleInput.js
@@ -40,7 +40,7 @@ export default class HandleInput extends React.Component {
             title='Valid domain name, including .'
             value={this.state.immer} disabled={this.props.lockImmer}
           />
-          <span>]</span>
+          <span className='handle-bracket'>]</span>
         </div>
       </div>
     )

--- a/views/components/HandleInput.js
+++ b/views/components/HandleInput.js
@@ -1,11 +1,11 @@
 import React from 'react'
 
 export default class HandleInput extends React.Component {
-  constructor () {
-    super()
+  constructor (props) {
+    super(props)
     this.state = {
-      username: '',
-      immer: ''
+      username: props.username || '',
+      immer: props.immer || ''
     }
     this.handleInput = this.handleInput.bind(this)
   }
@@ -28,6 +28,7 @@ export default class HandleInput extends React.Component {
             placeholder='username'
             required pattern='^[A-Za-z0-9-]{3,32}$'
             title='Letters, numbers, &amp; dashes only, between 3 and 32 characters'
+            value={this.state.username}
           />
           [
           <input
@@ -37,11 +38,18 @@ export default class HandleInput extends React.Component {
             placeholder='your.immer'
             required pattern='localhost(:\d+)?|.+\..+'
             title='Valid domain name, including .'
-            value={this.props.immer} disabled={!!this.props.immer}
+            value={this.state.immer} disabled={this.props.lockImmer}
           />
           ]
         </div>
       </div>
     )
+  }
+
+  componentDidUpdate () {
+    const { username, immer } = this.props
+    if (username !== this.state.username || immer !== this.state.immer) {
+      this.setState({ username, immer })
+    }
   }
 }

--- a/views/components/Layout.js
+++ b/views/components/Layout.js
@@ -11,7 +11,7 @@ export default function Layout (props) {
       <div className='aesthetic-effect-crt bg' />
       <div className='content'>
         <h1 className='aesthetic-50-transparent-color'>{title}</h1>
-        <div className='aesthetic-windows-95-modal'>
+        <div className='aesthetic-windows-95-modal main-content'>
           <div className='aesthetic-windows-95-modal-title-bar'>
             <div className='aesthetic-windows-95-modal-title-bar-text'>
               {props.contentTitle}

--- a/views/components/PasswordInput.js
+++ b/views/components/PasswordInput.js
@@ -39,14 +39,8 @@ export default class PasswordInput extends React.Component {
   }
 
   handleFocus () {
-    // avoid repeated scroll changes when interacting with picker
     if (!this.state.showPicker) {
       this.setState({ showPicker: true })
-      // timeout the transition delay so it has full height to calculate scroll
-      window.setTimeout(() => {
-        this.wrapperRef.current
-          .scrollIntoView({ behavior: 'smooth', block: 'start' })
-      }, 500)
     }
   }
 

--- a/views/components/PasswordInput.js
+++ b/views/components/PasswordInput.js
@@ -10,8 +10,8 @@ store.setHandlers({
 })
 
 export default class PasswordInput extends React.Component {
-  constructor () {
-    super()
+  constructor (props) {
+    super(props)
     this.wrapperRef = React.createRef()
     this.inputRef = React.createRef()
     this.state = {

--- a/views/layout.njk
+++ b/views/layout.njk
@@ -8,6 +8,7 @@
         imageAttributionUrl: '{{ imageAttributionUrl }}',
         imageAttributionText: '{{ imageAttributionText }}',
         username: '{{ username }}',
+        immer: '{{ immer }}',
         clientName: '{{ clientName }}',
         redirectUri: '{{ redirectUri }}',
         transactionId: '{{ transactionId }}',

--- a/views/login/login.js
+++ b/views/login/login.js
@@ -69,8 +69,8 @@ class Login extends React.Component {
     this.setState({ fetching: true, canSubmitHandle: false })
     let state
     let redirectUri
-    const { immer } = this.state
-    const search = new URLSearchParams({ immer }).toString()
+    const { username, immer } = this.state
+    const search = new URLSearchParams({ username, immer }).toString()
     window.fetch(`/auth/home?${search}`, {
       headers: {
         Accept: 'application/json'

--- a/views/login/login.js
+++ b/views/login/login.js
@@ -265,7 +265,11 @@ class Login extends React.Component {
           {this.state.tab === 'Register' &&
             <div id='register-form' className='aesthetic-windows-95-container-indent'>
               <form action='/auth/user' method='post' onSubmit={this.handleRegister}>
-                <HandleInput immer={this.state.data.domain} lockImmer onChange={this.handleHandleInput} />
+                <HandleInput
+                  onChange={this.handleHandleInput}
+                  username={this.state.username}
+                  immer={this.state.data.domain} lockImmer
+                />
                 <div className='form-item'>
                   <label>Display name:</label>
                   <input
@@ -322,6 +326,7 @@ class Login extends React.Component {
   }
 
   componentDidMount () {
+    // if handle pre-filled, click lookup button
     if (this.state.username && this.state.immer) {
       this.handleLookup()
     }

--- a/views/login/login.js
+++ b/views/login/login.js
@@ -9,9 +9,10 @@ import Layout from '../components/Layout'
 import EmailInput from '../components/EmailInput'
 
 class Login extends React.Component {
-  constructor () {
-    super()
+  constructor (props) {
+    super(props)
     const qParams = new URLSearchParams(window.location.search)
+    const data = window._serverData || {}
     this.initialState = {
       local: false,
       isRemote: false,
@@ -24,13 +25,12 @@ class Login extends React.Component {
       canSubmitForgot: true
     }
     this.state = {
+      data,
       currentState: undefined,
-      data: window._serverData || {},
       tabs: ['Login', 'Register', 'Reset password'],
       tab: 'Login',
-      username: '',
-      immer: '',
-      handle: '',
+      username: data.username || '',
+      immer: data.immer || '',
       passwordError: qParams.has('passwordfail'),
       ...this.initialState
     }
@@ -227,7 +227,10 @@ class Login extends React.Component {
           {this.state.tab === 'Login' &&
             <div id='login-form' className='aesthetic-windows-95-container-indent'>
               <form method='post' onSubmit={this.handleLogin}>
-                <HandleInput onChange={this.handleHandleInput} />
+                <HandleInput
+                  onChange={this.handleHandleInput}
+                  username={this.state.username} immer={this.state.immer}
+                />
                 <PasswordInput hide={!this.state.local} autoFocus />
                 <div className={c({ 'form-item': true, hidden: !this.state.isRemote })}>
                   You will be redirected to your home immer to login
@@ -262,7 +265,7 @@ class Login extends React.Component {
           {this.state.tab === 'Register' &&
             <div id='register-form' className='aesthetic-windows-95-container-indent'>
               <form action='/auth/user' method='post' onSubmit={this.handleRegister}>
-                <HandleInput immer={this.state.data.domain} onChange={this.handleHandleInput} />
+                <HandleInput immer={this.state.data.domain} lockImmer onChange={this.handleHandleInput} />
                 <div className='form-item'>
                   <label>Display name:</label>
                   <input
@@ -315,8 +318,13 @@ class Login extends React.Component {
             </div>}
         </div>
       </div>
-
     )
+  }
+
+  componentDidMount () {
+    if (this.state.username && this.state.immer) {
+      this.handleLookup()
+    }
   }
 }
 


### PR DESCRIPTION
Quest 2 is missing a lot of emoji in its native font; switch to image-based rendering (and redo password revealer to allow image-based emoji renders)

Handle passing:
1. If handle included in authorization redirect_uri, extract it and store in session
2. When redirected to login, retreive stored handle and pass it to login view
3. In login view, prefill handle if provded

Paired with changes in hubs (immers-space/hubs#4) that insert handle into inter-immer links and authorize requests, allows users to skip entering their handle altogether when moving between hubs