### PR TITLE
OAuth2 Scopes with user control

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ monetizationPointer | [Payment pointer](https://webmonetization.org/docs/ilp-wal
 dbName | Database name to use with MongoDb | mongodb
 port | Port number for immers sever | 8081
 smtpFrom | From address for emails | noreplay@mail.`domain`
+emailOptInURL | Link to an opt-in form for email updates to show on registration page | None
+emailOptInParam | Query parameter for `emailOptInURL` for the e-mail address | Use opt-in url without inserting e-mail
+emailOptInNameParam | Query parameter for `emailOptInURL` for the name | Use opt-in url without inserting name
 keyPath, certPath, caPath | Local development only. Relative paths to certificate files | None
 
 ## Local dev

--- a/common/scopes.js
+++ b/common/scopes.js
@@ -1,0 +1,39 @@
+// actual permissions scopes
+module.exports.scopes = {
+  // level 0 scopes don't grant any more access than unauthorized requests on public routes
+  viewProfile: { level: 0, description: ['Use your name and avatar'], name: 'viewProfile' },
+  viewPublic: { level: 0, description: ['View public posts in Immers Chat'], name: 'viewPublic' },
+
+  viewFriends: { level: 1, description: ['View your friends list'], name: 'viewFriends' },
+  postLocation: { level: 1, description: ['Share your presence here with friends'], name: 'postLocation' },
+
+  viewPrivate: { level: 2, description: ['View private posts in Immers chat'], name: 'viewPrivate' },
+  creative: {
+    level: 2,
+    description: [
+      'Save changes to your name and avatar',
+      'Make posts in Immers chat and share selfies',
+      'Save new avatars and inventory items'
+    ],
+    name: 'creative'
+  },
+  addFriends: { level: 2, description: ['Send and accept friend requests'], name: 'addFriends' },
+  addBlocks: { level: 2, description: ['Add to your blocklist'], name: 'addBlocks' },
+
+  destructive: {
+    level: 3,
+    description: [
+      'Remove existing friends and blocks',
+      'Delete Immers chats, avatars, and inventory items'
+    ],
+    name: 'destructive'
+  }
+}
+
+// common bundles of scopes
+module.exports.roles = [
+  { label: 'Just identity', name: 'public', level: 0 },
+  { label: 'Share location', name: 'friends', level: 1 },
+  { label: 'Social features', name: 'modAdditive', level: 2 },
+  { label: 'Account maintenance', name: 'modFull', level: 3 }
+]

--- a/index.js
+++ b/index.js
@@ -41,7 +41,10 @@ const {
   backgroundImage,
   icon,
   imageAttributionText,
-  imageAttributionUrl
+  imageAttributionUrl,
+  emailOptInURL,
+  emailOptInParam,
+  emailOptInNameParam
 } = process.env
 const renderConfig = {
   name,
@@ -52,7 +55,8 @@ const renderConfig = {
   backgroundImage,
   icon,
   imageAttributionText,
-  imageAttributionUrl
+  imageAttributionUrl,
+  emailOptInURL
 }
 const mongoURI = `mongodb://${dbHost}:${dbPort}`
 const app = express()
@@ -119,6 +123,25 @@ app.route('/auth/reset')
     res.render('dist/reset/reset.html', renderConfig)
   })
   .post(auth.changePasswordAndReturn)
+/* redirect to an email opt-in form
+ doing this here rather than client-side because the URL was
+ troublesome to pass to the client via renderConfig due to sanitization
+*/
+app.get('/auth/optin', (req, res) => {
+  if (!emailOptInURL) {
+    return res.sendStatus(404)
+  }
+  const url = new URL(emailOptInURL)
+  const search = new URLSearchParams(url.search)
+  if (emailOptInParam && req.query.email) {
+    search.set(emailOptInParam, req.query.email)
+  }
+  if (emailOptInNameParam && req.query.name) {
+    search.set(emailOptInNameParam, req.query.name)
+  }
+  url.search = search
+  res.redirect(url)
+})
 
 async function registerActor (req, res, next) {
   const preferredUsername = req.body.username

--- a/migrations/20210430215117-hash_emails.js
+++ b/migrations/20210430215117-hash_emails.js
@@ -1,0 +1,32 @@
+const crypto = require('crypto')
+
+module.exports = {
+  async up (db, client) {
+    const users = await db.collection('users')
+      .find({})
+      .project({ _id: 1, email: 1 })
+      .toArray()
+    const session = client.startSession()
+    try {
+      await session.withTransaction(() => {
+        return Promise.all(users.map(async user => {
+          if (!user.email) {
+            return
+          }
+          return db.collection('users').updateOne({ _id: user._id }, {
+            $set: {
+              email: crypto.createHash('sha256').update(user.email.toLowerCase()).digest('base64')
+            }
+          })
+        }))
+      })
+    } finally {
+      await session.endSession()
+    }
+  },
+
+  async down () {
+    // can't undo this; that's the point :)
+    return Promise.resolve('ok')
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "immers",
-  "version": "1.0.0",
+  "version": "1.1.0-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "nodemailer": "^6.5.0",
     "nunjucks": "^3.2.3",
     "oauth2orize": "^1.11.0",
+    "overlaps": "^1.0.0",
     "parcel-bundler": "^1.12.5",
     "passport": "^0.4.1",
     "passport-anonymous": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "immers",
-  "version": "1.0.0",
+  "version": "1.1.0-alpha.0",
   "description": "ActivityPub server for the metaverse",
   "main": "index.js",
   "engines": {

--- a/src/auth.js
+++ b/src/auth.js
@@ -125,7 +125,7 @@ function localToken (req, res) {
     }
     res.send(token)
   }
-  authdb.createAccessToken(client, req.user, { origin: domain }, done)
+  authdb.createAccessToken(client, req.user, { origin: domain, scope: ['*'] }, done)
 }
 
 // dynamic cors for oauth clients

--- a/src/auth.js
+++ b/src/auth.js
@@ -324,6 +324,7 @@ module.exports = {
         params.origin = `${origin.protocol}//${origin.host}`
         // express protocol does not include colon
         params.issuer = `https://${domain}`
+        params.scope = ['*']
         return done(null, true, params)
       }
       // Otherwise ask user
@@ -335,6 +336,7 @@ module.exports = {
         username: request.user.username,
         clientName: request.oauth2.client.name,
         redirectUri: request.oauth2.client.redirectUri,
+        preferredScope: request.oauth2.req.scope.join(' '),
         name,
         monetizationPointer,
         googleFont,
@@ -357,6 +359,7 @@ module.exports = {
       params.origin = `${origin.protocol}//${origin.host}`
       // express protocol does not include colon
       params.issuer = `https://${domain}`
+      params.scope = req.body.scope?.split(' ') || []
       done(null, params)
     })
   ]

--- a/src/auth.js
+++ b/src/auth.js
@@ -83,9 +83,9 @@ passport.use(new EasyNoPassword(
       const url = `https://${domain}/auth/reset?username=${safeEmail}&token=${token}`
       const info = await transporter.sendMail({
         from: `"${name}" <${smtpFrom}>`,
-        to: user.email,
+        to: email,
         subject: `${user.username}: your ${name} password reset link`,
-        text: `${user.username}, please use this link to reset you ${name} profile password: ${url}`
+        text: `${user.username}, please use this link to reset your ${name} profile password: ${url}`
       })
       if (process.env.NODE_ENV !== 'production') {
         console.log(nodemailer.getTestMessageUrl(info))
@@ -125,7 +125,7 @@ function localToken (req, res) {
     }
     res.send(token)
   }
-  authdb.createAccessToken(client, req.user, { origin: domain, scope: ['*'] }, done)
+  authdb.createAccessToken(client, req.user, { origin: `https://${domain}`, scope: ['*'] }, done)
 }
 
 // dynamic cors for oauth clients

--- a/src/authdb.js
+++ b/src/authdb.js
@@ -92,15 +92,15 @@ module.exports = {
       const token = await uid(128)
       const expiry = new Date(Date.now() + tokenAge)
       await db.collection('tokens')
-        .insertOne({ token, user, clientId, expiry, tokenType, origin: ares.origin })
-      return done(null, token, { token_type: tokenType, issuer: ares.issuer })
+        .insertOne({ token, user, clientId, expiry, tokenType, origin: ares.origin, scope: ares.scope })
+      return done(null, token, { token_type: tokenType, issuer: ares.issuer, scope: ares.scope.join(' ') })
     } catch (err) { done(err) }
   },
   async validateAccessToken (token, done) {
     try {
       const tokenDoc = await db.collection('tokens').findOne({ token })
       if (!tokenDoc) { return done(null, false) }
-      done(null, tokenDoc.user, { scope: '*', origin: tokenDoc.origin })
+      done(null, tokenDoc.user, { scope: tokenDoc.scope, origin: tokenDoc.origin })
     } catch (err) { done(err) }
   },
   // immers api methods (promises instead of callbacks)

--- a/views/ap/Post.js
+++ b/views/ap/Post.js
@@ -77,9 +77,9 @@ export function ImmerLink ({ place }) {
   // inject user handle into desintation url so they don't have to type it
   try {
     const url = new URL(placeUrl)
-    const search = new URLSearchParams(url.search)
-    search.set('me', handle)
-    url.search = search.toString()
+    const hashParams = new URLSearchParams()
+    hashParams.set("me", handle)
+    url.hash = hashParams.toString()
     placeUrl = url.toString()
   } catch (ignore) {
     /* if fail, leave original url unchanged */

--- a/views/assets/immers.css
+++ b/views/assets/immers.css
@@ -71,6 +71,10 @@ h1 {
   align-items: center;
 }
 
+.form-footer {
+  margin: 0 20px;
+  max-width: 590px;
+}
 .form-item, .form-item label, .form-item input {
   transition: all 0.5s ease-in-out;
   overflow: hidden;
@@ -173,6 +177,11 @@ button[disabled] {
 .handle-bracket {
   display: inline-block;
   width: 10px;
+}
+
+/* okay we're all sick of the flicker */
+.aesthetic-effect-crt::after {
+  animation: none !important;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/views/components/EmailOptIn.js
+++ b/views/components/EmailOptIn.js
@@ -1,0 +1,24 @@
+import React from 'react'
+
+export default function EmailOptIn () {
+  const { emailOptInURL } = window._serverData
+  const onClick = event => {
+    event.preventDefault()
+    const search = new URLSearchParams()
+    const email = document.querySelector('input[name=email]').value
+    if (email) {
+      search.set('email', email)
+    }
+    const name = document.querySelector('input[name=name]').value
+    if (name) {
+      search.set('name', name)
+    }
+    window.open(`/auth/optin?${search}`, '_blank', 'noopener')
+  }
+  return (
+    <p className='form-footer'>
+      We don't save your e-mail, just an encrypted hash of it for password resets.{' '}
+      {emailOptInURL && (<span><a href={emailOptInURL} onClick={onClick}>Click here</a> to opt-in to our e-mail contact list.</span>)}
+    </p>
+  )
+}

--- a/views/dialog/dialog.css
+++ b/views/dialog/dialog.css
@@ -3,9 +3,14 @@
   justify-content: space-around;
 }
 
+.roleOption {
+  margin: 0 8px;
+}
+
 .roleOption input {
   display: block;
   width: 100%;
+  height: 24px;
 }
 
 .permissionsInfo {

--- a/views/dialog/dialog.css
+++ b/views/dialog/dialog.css
@@ -1,0 +1,23 @@
+#roleOptions {
+  display: flex;
+  justify-content: space-around;
+}
+
+.roleOption input {
+  display: block;
+  width: 100%;
+}
+
+.permissionsInfo {
+  display: inline-block;
+  width: 50%;
+  vertical-align: top;
+}
+
+.permissionsHeader {
+  text-align: center;
+}
+
+.permissionsContainer {
+  margin-top: 15px;
+}

--- a/views/dialog/dialog.js
+++ b/views/dialog/dialog.js
@@ -2,31 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import Layout from '../components/Layout'
 import './dialog.css'
-
-const perms = {
-  viewProfile: { level: 0, description: 'Use your name and avatar' },
-  viewPublic: { level: 0, description: 'View public posts in Immers Chat' },
-  viewFriends: { level: 1, description: 'View your friends list' },
-  viewPrivate: { level: 1, description: 'View private posts in Immers chat' },
-  postLocation: { level: 2, description: 'Share your presence here with friends' },
-  postUpdates: { level: 2, description: 'Save changes to your name and avatar' },
-  postChat: { level: 2, description: 'Make posts in Immers chat and share selfies' },
-  addFriends: { level: 3, description: 'Send and accept friend requests' },
-  addBlocks: { level: 3, description: 'Add to your blocklist' },
-  addInventory: { level: 3, description: 'Save new avatars and inventory items' },
-  removeFriends: { level: 4, description: 'Remove existing friends' },
-  removeBlocks: { level: 4, description: 'Undo past blocks' },
-  removeInventory: { level: 4, description: 'Delete avatars and inventory items' },
-  deletePosts: { level: 4, description: 'Delete Immers chats' }
-}
-
-const roleLevels = {
-  public: 0,
-  readOnly: 1,
-  setStatus: 2,
-  modAdditive: 3,
-  modFull: 4
-}
+import { scopes, roles } from '../../common/scopes'
 
 class Dialog extends React.Component {
   constructor () {
@@ -34,28 +10,31 @@ class Dialog extends React.Component {
     const data = window._serverData || {}
     this.state = {
       ...data,
-      roleOptions: [
-        { label: 'Just identity', value: 'public', level: 0 },
-        { label: 'Read messages', value: 'readOnly', level: 1 },
-        { label: 'Status updates', value: 'setStatus', level: 2 },
-        { label: 'Making friends', value: 'modAdditive', level: 3 },
-        { label: 'Full access', value: 'modFull', level: 4 }
-      ],
+      roleOptions: roles,
       selectedRole: 'public'
     }
     const preferredScope = data.preferredScope?.[0]
-    if (this.state.roleOptions.find(({ value }) => value === preferredScope)) {
+    if (this.state.roleOptions.find(({ name }) => name === preferredScope)) {
       this.state.selectedRole = preferredScope
     }
   }
 
+  scopesToItems (scopes) {
+    return scopes.map(scope => scope.description)
+      .flat()
+      .map((text, i) => <li key={i}>{text}</li>)
+  }
+
   render () {
-    const roleLevel = roleLevels[this.state.selectedRole]
-    const cans = Object.entries(perms)
-      .filter(([, { level }]) => level <= roleLevel)
-    const cannots = Object.entries(perms)
-      .filter(([, { level }]) => level > roleLevel)
-    const roles = cans.map(([role]) => role).join(' ')
+    const roleLevel = this.state.roleOptions
+      .find(({ name }) => name === this.state.selectedRole)
+      .level
+    // const roleLevel = roles[this.state.selectedRole]
+    const cans = Object.values(scopes)
+      .filter(({ level }) => level <= roleLevel)
+    const cannots = Object.values(scopes)
+      .filter(({ level }) => level > roleLevel)
+    const approvedScopes = cans.map(({ name }) => name).join(' ')
     return (
       <div className='aesthetic-windows-95-container-indent'>
         <p>Hi {this.state.username}!</p>
@@ -66,15 +45,15 @@ class Dialog extends React.Component {
 
         <form action='/auth/decision' method='post'>
           <input name='transaction_id' type='hidden' value={this.state.transactionId} />
-          <input name='scope' type='hidden' value={roles} />
+          <input name='scope' type='hidden' value={approvedScopes} />
           <div id='roleOptions'>
             {this.state.roleOptions.map(role =>
-              <div key={role.value} className='roleOption'>
+              <div key={role.name} className='roleOption'>
                 <label>
                   <input
-                    name='roleGranted' type='radio' value={role.value}
-                    checked={this.state.selectedRole === role.value}
-                    onChange={() => this.setState({ selectedRole: role.value })}
+                    name='roleGranted' type='radio' value={role.name}
+                    checked={this.state.selectedRole === role.name}
+                    onChange={() => this.setState({ selectedRole: role.name })}
                   />
                   {role.label}
                 </label>
@@ -85,13 +64,13 @@ class Dialog extends React.Component {
             <div className='permissionsInfo'>
               <div className='permissionsHeader'>CAN</div>
               <ul>
-                {cans.map(([name, { description }]) => <li key={name}>{description}</li>)}
+                {this.scopesToItems(cans)}
               </ul>
             </div>
             <div className='permissionsInfo'>
               <div className='permissionsHeader'>CANNOT</div>
               <ul>
-                {cannots.map(([name, { description }]) => <li key={name}>{description}</li>)}
+                {this.scopesToItems(cannots)}
               </ul>
             </div>
           </div>

--- a/views/dialog/dialog.js
+++ b/views/dialog/dialog.js
@@ -1,25 +1,100 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import Layout from '../components/Layout'
+import './dialog.css'
+
+const perms = {
+  viewProfile: { level: 0, description: 'Use your name and avatar' },
+  viewPublic: { level: 0, description: 'View public posts in Immers Chat' },
+  viewFriends: { level: 1, description: 'View your friends list' },
+  viewPrivate: { level: 1, description: 'View private posts in Immers chat' },
+  postLocation: { level: 2, description: 'Share your presence here with friends' },
+  postUpdates: { level: 2, description: 'Save changes to your name and avatar' },
+  postChat: { level: 2, description: 'Make posts in Immers chat and share selfies' },
+  addFriends: { level: 3, description: 'Send and accept friend requests' },
+  addBlocks: { level: 3, description: 'Add to your blocklist' },
+  addInventory: { level: 3, description: 'Save new avatars and inventory items' },
+  removeFriends: { level: 4, description: 'Remove existing friends' },
+  removeBlocks: { level: 4, description: 'Undo past blocks' },
+  removeInventory: { level: 4, description: 'Delete avatars and inventory items' },
+  deletePosts: { level: 4, description: 'Delete Immers chats' }
+}
+
+const roleLevels = {
+  public: 0,
+  readOnly: 1,
+  setStatus: 2,
+  modAdditive: 3,
+  modFull: 4
+}
 
 class Dialog extends React.Component {
   constructor () {
     super()
     const data = window._serverData || {}
     this.state = {
-      ...data
+      ...data,
+      roleOptions: [
+        { label: 'Just identity', value: 'public', level: 0 },
+        { label: 'Read messages', value: 'readOnly', level: 1 },
+        { label: 'Status updates', value: 'setStatus', level: 2 },
+        { label: 'Making friends', value: 'modAdditive', level: 3 },
+        { label: 'Full access', value: 'modFull', level: 4 }
+      ],
+      selectedRole: 'public'
+    }
+    const preferredScope = data.preferredScope?.[0]
+    if (this.state.roleOptions.find(({ value }) => value === preferredScope)) {
+      this.state.selectedRole = preferredScope
     }
   }
 
   render () {
+    const roleLevel = roleLevels[this.state.selectedRole]
+    const cans = Object.entries(perms)
+      .filter(([, { level }]) => level <= roleLevel)
+    const cannots = Object.entries(perms)
+      .filter(([, { level }]) => level > roleLevel)
+    const roles = cans.map(([role]) => role).join(' ')
     return (
       <div className='aesthetic-windows-95-container-indent'>
         <p>Hi {this.state.username}!</p>
-        <p><b>{this.state.clientName}</b> ({this.state.redirectUri}) is requesting access to your account.</p>
-        <p>Do you approve?</p>
+        <p>
+          You're headed to <b>{this.state.clientName}</b> ({this.state.redirectUri}).
+        </p>
+        <p>How would you like to use your account while you're there?</p>
 
         <form action='/auth/decision' method='post'>
           <input name='transaction_id' type='hidden' value={this.state.transactionId} />
+          <input name='scope' type='hidden' value={roles} />
+          <div id='roleOptions'>
+            {this.state.roleOptions.map(role =>
+              <div key={role.value} className='roleOption'>
+                <label>
+                  <input
+                    name='roleGranted' type='radio' value={role.value}
+                    checked={this.state.selectedRole === role.value}
+                    onChange={() => this.setState({ selectedRole: role.value })}
+                  />
+                  {role.label}
+                </label>
+              </div>
+            )}
+          </div>
+          <div className='permissionsContainer'>
+            <div className='permissionsInfo'>
+              <div className='permissionsHeader'>CAN</div>
+              <ul>
+                {cans.map(([name, { description }]) => <li key={name}>{description}</li>)}
+              </ul>
+            </div>
+            <div className='permissionsInfo'>
+              <div className='permissionsHeader'>CANNOT</div>
+              <ul>
+                {cannots.map(([name, { description }]) => <li key={name}>{description}</li>)}
+              </ul>
+            </div>
+          </div>
           <div className='form-item'>
             <span className='aesthetic-windows-95-button'>
               <button type='submit' name='allow' id='allow'>Allow</button>

--- a/views/layout.njk
+++ b/views/layout.njk
@@ -13,7 +13,8 @@
         redirectUri: '{{ redirectUri }}',
         transactionId: '{{ transactionId }}',
         loggedInUser: '{{ loggedInUser }}',
-        preferredScope: '{{ preferredScope }}'.split(' ')
+        preferredScope: '{{ preferredScope }}'.split(' '),
+        emailOptInURL: '{{ emailOptInURL }}'
       }
     </script>
     <title>{% block title %}{{ name }}{% endblock %}</title>

--- a/views/layout.njk
+++ b/views/layout.njk
@@ -12,7 +12,8 @@
         clientName: '{{ clientName }}',
         redirectUri: '{{ redirectUri }}',
         transactionId: '{{ transactionId }}',
-        loggedInUser: '{{ loggedInUser }}'
+        loggedInUser: '{{ loggedInUser }}',
+        preferredScope: '{{ preferredScope }}'.split(' ')
       }
     </script>
     <title>{% block title %}{{ name }}{% endblock %}</title>

--- a/views/login/login.js
+++ b/views/login/login.js
@@ -7,6 +7,7 @@ import HandleInput from '../components/HandleInput'
 import PasswordInput from '../components/PasswordInput'
 import Layout from '../components/Layout'
 import EmailInput from '../components/EmailInput'
+import EmailOptIn from '../components/EmailOptIn'
 
 class Login extends React.Component {
   constructor (props) {
@@ -299,6 +300,7 @@ class Login extends React.Component {
                   </span>
                 </div>
               </form>
+              <EmailOptIn />
             </div>}
           {this.state.tab === 'Reset password' &&
             <div className='aesthetic-windows-95-container-indent'>


### PR DESCRIPTION
Adds ability to limit the level of access you grant when visiting foreign immers
* Define individual scopes and roles (bundles of scopes)
* Update OAuth confirm dialog to take a requested role as input, allow user to change role before granting, and describe the permissions associated with the role
* Enforce scope restrictions on API endpoints