### PR TITLE
Hash emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ monetizationPointer | [Payment pointer](https://webmonetization.org/docs/ilp-wal
 dbName | Database name to use with MongoDb | mongodb
 port | Port number for immers sever | 8081
 smtpFrom | From address for emails | noreplay@mail.`domain`
+emailOptInURL | Link to an opt-in form for email updates to show on registration page | None
+emailOptInParam | Query parameter for `emailOptInURL` for the e-mail address | Use opt-in url without inserting e-mail
+emailOptInNameParam | Query parameter for `emailOptInURL` for the name | Use opt-in url without inserting name
 keyPath, certPath, caPath | Local development only. Relative paths to certificate files | None
 
 ## Local dev

--- a/index.js
+++ b/index.js
@@ -41,7 +41,10 @@ const {
   backgroundImage,
   icon,
   imageAttributionText,
-  imageAttributionUrl
+  imageAttributionUrl,
+  emailOptInURL,
+  emailOptInParam,
+  emailOptInNameParam
 } = process.env
 const renderConfig = {
   name,
@@ -52,7 +55,8 @@ const renderConfig = {
   backgroundImage,
   icon,
   imageAttributionText,
-  imageAttributionUrl
+  imageAttributionUrl,
+  emailOptInURL
 }
 const mongoURI = `mongodb://${dbHost}:${dbPort}`
 const app = express()
@@ -119,6 +123,25 @@ app.route('/auth/reset')
     res.render('dist/reset/reset.html', renderConfig)
   })
   .post(auth.changePasswordAndReturn)
+/* redirect to an email opt-in form
+ doing this here rather than client-side because the URL was
+ troublesome to pass to the client via renderConfig due to sanitization
+*/
+app.get('/auth/optin', (req, res) => {
+  if (!emailOptInURL) {
+    return res.sendStatus(404)
+  }
+  const url = new URL(emailOptInURL)
+  const search = new URLSearchParams(url.search)
+  if (emailOptInParam && req.query.email) {
+    search.set(emailOptInParam, req.query.email)
+  }
+  if (emailOptInNameParam && req.query.name) {
+    search.set(emailOptInNameParam, req.query.name)
+  }
+  url.search = search
+  res.redirect(url)
+})
 
 async function registerActor (req, res, next) {
   const preferredUsername = req.body.username

--- a/migrations/20210430215117-hash_emails.js
+++ b/migrations/20210430215117-hash_emails.js
@@ -1,0 +1,32 @@
+const crypto = require('crypto')
+
+module.exports = {
+  async up (db, client) {
+    const users = await db.collection('users')
+      .find({})
+      .project({ _id: 1, email: 1 })
+      .toArray()
+    const session = client.startSession()
+    try {
+      await session.withTransaction(() => {
+        return Promise.all(users.map(async user => {
+          if (!user.email) {
+            return
+          }
+          return db.collection('users').updateOne({ _id: user._id }, {
+            $set: {
+              email: crypto.createHash('sha256').update(user.email.toLowerCase()).digest('base64')
+            }
+          })
+        }))
+      })
+    } finally {
+      await session.endSession()
+    }
+  },
+
+  async down () {
+    // can't undo this; that's the point :)
+    return Promise.resolve('ok')
+  }
+}

--- a/src/auth.js
+++ b/src/auth.js
@@ -83,9 +83,9 @@ passport.use(new EasyNoPassword(
       const url = `https://${domain}/auth/reset?username=${safeEmail}&token=${token}`
       const info = await transporter.sendMail({
         from: `"${name}" <${smtpFrom}>`,
-        to: user.email,
+        to: email,
         subject: `${user.username}: your ${name} password reset link`,
-        text: `${user.username}, please use this link to reset you ${name} profile password: ${url}`
+        text: `${user.username}, please use this link to reset your ${name} profile password: ${url}`
       })
       if (process.env.NODE_ENV !== 'production') {
         console.log(nodemailer.getTestMessageUrl(info))

--- a/views/assets/immers.css
+++ b/views/assets/immers.css
@@ -179,6 +179,11 @@ button[disabled] {
   width: 10px;
 }
 
+/* okay we're all sick of the flicker */
+.aesthetic-effect-crt::after {
+  animation: none !important;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .aesthetic-effect-crt::after,
   .aesthetic-effect-text-glitch::before,

--- a/views/assets/immers.css
+++ b/views/assets/immers.css
@@ -71,6 +71,10 @@ h1 {
   align-items: center;
 }
 
+.form-footer {
+  margin: 0 20px;
+  max-width: 590px;
+}
 .form-item, .form-item label, .form-item input {
   transition: all 0.5s ease-in-out;
   overflow: hidden;

--- a/views/components/EmailOptIn.js
+++ b/views/components/EmailOptIn.js
@@ -1,0 +1,24 @@
+import React from 'react'
+
+export default function EmailOptIn () {
+  const { emailOptInURL } = window._serverData
+  const onClick = event => {
+    event.preventDefault()
+    const search = new URLSearchParams()
+    const email = document.querySelector('input[name=email]').value
+    if (email) {
+      search.set('email', email)
+    }
+    const name = document.querySelector('input[name=name]').value
+    if (name) {
+      search.set('name', name)
+    }
+    window.open(`/auth/optin?${search}`, '_blank', 'noopener')
+  }
+  return (
+    <p className='form-footer'>
+      We don't save your e-mail, just an encrypted hash of it for password resets.{' '}
+      {emailOptInURL && (<span><a href={emailOptInURL} onClick={onClick}>Click here</a> to opt-in to our e-mail contact list.</span>)}
+    </p>
+  )
+}

--- a/views/layout.njk
+++ b/views/layout.njk
@@ -13,7 +13,8 @@
         redirectUri: '{{ redirectUri }}',
         transactionId: '{{ transactionId }}',
         loggedInUser: '{{ loggedInUser }}',
-        preferredScope: '{{ preferredScope }}'.split(' ')
+        preferredScope: '{{ preferredScope }}'.split(' '),
+        emailOptInURL: '{{ emailOptInURL }}'
       }
     </script>
     <title>{% block title %}{{ name }}{% endblock %}</title>

--- a/views/login/login.js
+++ b/views/login/login.js
@@ -7,6 +7,7 @@ import HandleInput from '../components/HandleInput'
 import PasswordInput from '../components/PasswordInput'
 import Layout from '../components/Layout'
 import EmailInput from '../components/EmailInput'
+import EmailOptIn from '../components/EmailOptIn'
 
 class Login extends React.Component {
   constructor (props) {
@@ -299,6 +300,7 @@ class Login extends React.Component {
                   </span>
                 </div>
               </form>
+              <EmailOptIn />
             </div>}
           {this.state.tab === 'Reset password' &&
             <div className='aesthetic-windows-95-container-indent'>


### PR DESCRIPTION
No more storing plaintext emails.
* Save an sha256 hash of the email,
* Hash the input email before querying when doing password reset
* Use the input email as the address for the email
* Includes migration to hash all existing emails
* Adds an explanatory note to the registration form with configurable link to email opt-in