### PR TITLE
Fix unable to post activities from profile page

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -125,7 +125,7 @@ function localToken (req, res) {
     }
     res.send(token)
   }
-  authdb.createAccessToken(client, req.user, { origin: domain, scope: ['*'] }, done)
+  authdb.createAccessToken(client, req.user, { origin: `https://${domain}`, scope: ['*'] }, done)
 }
 
 // dynamic cors for oauth clients


### PR DESCRIPTION
The friends list shows friend requests with accept/reject buttons, but it turns out those buttons don't work right now because a malformed token causes an exception in the cors middleware. This fixes it