### PR TITLE
Support logins from destination-only sites (i.e. without a local Immers Server)

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -312,29 +312,6 @@ function stashHandle (req, res, next) {
   }
   next()
 }
-/**
- * To allow destination-only immers (no server), we enable token grants
- * without a registered client. To avoid redirect attacks, only issue
- * tokens for the requesting domain. OAuth2orize doesn't provided
- * the access to request headers in its client validation callbacks,
- * so this check is done early
- */
-function validateAnonymousClient (req, res, next) {
-  if (req.query.client_id && req.query.client_id !== 'undefined') {
-    return next()
-  }
-  try {
-    const origin = new URL(req.get('Referer'))
-    const redirect = new URL(req.query.redirect_uri)
-    if (origin.hostname !== redirect.hostname) {
-      return res.status(403)
-        .send('Anonymous clients must use redirect uri on same host')
-    }
-  } catch (err) {
-    return res.status(400).send('Referer header required for anonymous clients')
-  }
-  next()
-}
 
 module.exports = {
   authdb,
@@ -361,7 +338,6 @@ module.exports = {
   // new client authorization & token request
   authorization: [
     stashHandle,
-    validateAnonymousClient,
     login.ensureLoggedIn('/auth/login'),
     server.authorization(authdb.validateClient, (client, user, scope, type, req, done) => {
       // Auto-approve for home immer

--- a/src/authdb.js
+++ b/src/authdb.js
@@ -66,7 +66,7 @@ module.exports = {
     if (client._id === 'anonymous') {
       return done(null, `${anonClientPrefix}${JSON.stringify(client)}`)
     }
-    done(null, client._id)
+    done(null, client._id.toString())
   },
   async deserializeClient (id, done) {
     try {

--- a/views/dialog/dialog.css
+++ b/views/dialog/dialog.css
@@ -26,3 +26,9 @@
 .permissionsContainer {
   margin-top: 15px;
 }
+
+.permissionsInfo li {
+  font-size: 20px;
+  line-height: 80%;
+  padding-bottom: 3px;
+}

--- a/views/dialog/dialog.js
+++ b/views/dialog/dialog.js
@@ -37,11 +37,16 @@ class Dialog extends React.Component {
     const approvedScopes = cans.map(({ name }) => name).join(' ')
     return (
       <div className='aesthetic-windows-95-container-indent'>
-        <p>Hi {this.state.username}!</p>
         <p>
-          You're headed to <b>{this.state.clientName}</b> ({this.state.redirectUri}).
+          Hi {this.state.username}! <br />
+          You're headed to {
+            this.state.clientName
+              ? <span><b>{this.state.clientName}</b> ({this.state.redirectUri}).</span>
+              : <span><b>{this.state.redirectUri}</b></span>
+            }
+          <br />
+          How would you like to use your account while you're there?
         </p>
-        <p>How would you like to use your account while you're there?</p>
 
         <form action='/auth/decision' method='post'>
           <input name='transaction_id' type='hidden' value={this.state.transactionId} />

--- a/views/login/login.js
+++ b/views/login/login.js
@@ -38,6 +38,10 @@ class Login extends React.Component {
     if (this.state.tabs.includes(data.loginTab)) {
       this.state.tab = data.loginTab
     }
+    const hash = window.location.hash.substring(1)
+    if (this.state.tabs.includes(hash)) {
+      this.state.tab = hash
+    }
     this.handleHandleInput = this.handleHandleInput.bind(this)
     this.handleLookup = this.handleLookup.bind(this)
     this.handleRedirect = this.handleRedirect.bind(this)


### PR DESCRIPTION
* allow anonymous clients
* condense OAuth dialog to reduce scrolling to get to allow button