### PR TITLE
Remove display name from registration form

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -218,9 +218,11 @@ async function validateNewUser (req, res, next) {
   } else {
     req.body.username = req.body.username.toLowerCase()
   }
-
-  if (!RegExp(nameCheck).test(req.body.name)) {
+  if (req.body.name && !RegExp(nameCheck).test(req.body.name)) {
     validMessage += `Display name must match ${nameCheck}. `
+  } else if (!req.body.name) {
+    // display name is optional in registration, default to username
+    req.body.name = req.body.username
   }
 
   if (validMessage) {

--- a/views/login/login.js
+++ b/views/login/login.js
@@ -278,14 +278,14 @@ class Login extends React.Component {
                   username={this.state.username}
                   immer={this.state.data.domain} lockImmer
                 />
-                <div className='form-item'>
+                {/* hidden & defaults to username, use custom css to reveal if wanted */}
+                <div className='form-item none'>
                   <label>Display name:</label>
                   <input
                     id='handle' className='aesthetic-windows-95-text-input'
                     type='text' name='name'
                     pattern='^[A-Za-z0-9_~ -]{3,32}$'
                     title='Letters, numbers, spaces, &amp; dashes only, between 3 and 32 characters'
-                    required
                   />
                 </div>
                 <EmailInput />


### PR DESCRIPTION
We've got reports that registration is too many steps, this removes one step by removing the display name input from the registration form. It will instead default to the same as username and can be updated later through a client