### PR TITLE
proxyMode env var, http server, express trust proxy setting

### DIFF
--- a/.env
+++ b/.env
@@ -25,3 +25,4 @@ easySecret=supersecret
 systemUserName=immerser
 systemDisplayName=Immerser One
 welcome=welcome.html
+proxyMode=

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ systemUserName | Username for a "Service" type actor representing the Immer, ena
 systemDisplayName | Sets the display name for the service actor | none
 welcome | HTML file for a message that will be delivered from the system user to new user's inboxes (requires `systemUserName`) | none (does not send message)
 keyPath, certPath, caPath | Local development only. Relative paths to certificate files | None
+proxyMode | Enable use behind an SSL-terminating proxy or load balancer, serves over http instead of https and sets Express `trust proxy` setting to the value of `proxyMode` (e.g. `1`, [other options](https://expressjs.com/en/guide/behind-proxies.html)) | none (serves over https with AutoEncrypt)
 
 ## Local dev
 

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ const auth = require('./src/auth')
 const AutoEncryptPromise = import('@small-tech/auto-encrypt')
 const { onShutdown } = require('node-graceful-shutdown')
 const morgan = require('morgan')
-const { debugOutput, parseHandle, apexDomain } = require('./src/utils')
+const { debugOutput, parseHandle, parseProxyMode, apexDomain } = require('./src/utils')
 const { apex, createImmersActor, deliverWelcomeMessage, routes, onInbox, onOutbox, outboxPost } = require('./src/apex')
 const { migrate } = require('./src/migrate')
 const { scopes } = require('./common/scopes')
@@ -306,12 +306,7 @@ migrate(mongoURI).catch((err) => {
   if (process.env.NODE_ENV === 'production') {
     if (proxyMode) {
       server = http.createServer(app)
-      let proxyValue = proxyMode === 'true'
-      if (!proxyValue) {
-        proxyValue = Number(proxyMode)
-      }
-      app.set('trust proxy', Number.isNaN(proxyValue) ? proxyMode : proxyValue)
-      console.log('proxy mode:', app.get('trust proxy'), typeof app.get('trust proxy'))
+      app.set('trust proxy', parseProxyMode(proxyMode))
     } else {
       server = AutoEncrypt.https.createServer({ domains: [domain] }, app)
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,6 +2,7 @@ const { parseDomain, ParseResultType } = require('parse-domain')
 
 module.exports = {
   parseHandle,
+  parseProxyMode,
   debugOutput,
   apexDomain
 }
@@ -26,6 +27,15 @@ function parseHandle (handle) {
       immer: match[2]
     }
   }
+}
+
+function parseProxyMode (proxyMode) {
+  try {
+    // boolean or number
+    return JSON.parse(proxyMode)
+  } catch (ignore) {}
+  // string
+  return proxyMode
 }
 
 function apexDomain (domain) {


### PR DESCRIPTION
Adds a proxyMode as a subset of production mode with typical config for running behind an SSL-terminating proxy