### PR TITLE
allow authenticated CORS requests from hub domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,45 @@ systemDisplayName | Sets the display name for the service actor | none
 welcome | HTML file for a message that will be delivered from the system user to new user's inboxes (requires `systemUserName`) | none (does not send message)
 keyPath, certPath, caPath | Local development only. Relative paths to certificate files | None
 
+## API access
+
+Most API access will be done with the [immers-client](https://github.com/immers-space/immers-client)
+library on your immersive website, but the immers server also attempts to
+parse your `domain` option to set the login
+session cookie on the apex domain so that it can be used in CORS requests.
+As long as your immers server and immersive website are on the same apex domain,
+e.g. immers.space and hub.immers.space, then you can make authenticated requests
+with the `credentials: 'include'` fetch option.
+
+Restore session for previously logged in user:
+
+```js
+let user
+const token = await fetch('https://your.immer/auth/token', { method: 'POST', credentials: 'include' })
+    .then(res => {
+        if (!res.ok) {
+            // 401 if not logged in
+            return undefined
+        }
+        return res.text()
+    })
+if (token) {
+    user = await window.fetch(`https://your.immer/auth/me`, {
+    headers: {
+      Accept: jsonldMime,
+      Authorization: `Bearer ${token}`
+    }
+  }).then(res => res.json());
+}
+```
+
+Log out of session without having to navigate to immers profile page:
+
+```js
+// no-cors mode tells it to ignore the redirect to the login page
+fetch('https://localhost:8081/auth/logout', { credentials: 'include', mode: 'no-cors' })
+```
+
 ## Local dev
 
 immers

--- a/README.md
+++ b/README.md
@@ -89,8 +89,7 @@ if (token) {
 Log out of session without having to navigate to immers profile page:
 
 ```js
-// no-cors mode tells it to ignore the redirect to the login page
-fetch('https://your.immer/auth/logout', { credentials: 'include', mode: 'no-cors' })
+fetch('https://your.immer/auth/logout', { method: 'POST', credentials: 'include' })
 ```
 
 ## Local dev

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ const token = await fetch('https://your.immer/auth/token', { method: 'POST', cre
 if (token) {
     user = await window.fetch(`https://your.immer/auth/me`, {
     headers: {
-      Accept: jsonldMime,
+      Accept: 'application/activity+json',
       Authorization: `Bearer ${token}`
     }
   }).then(res => res.json());

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Log out of session without having to navigate to immers profile page:
 
 ```js
 // no-cors mode tells it to ignore the redirect to the login page
-fetch('https://localhost:8081/auth/logout', { credentials: 'include', mode: 'no-cors' })
+fetch('https://your.immer/auth/logout', { credentials: 'include', mode: 'no-cors' })
 ```
 
 ## Local dev

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const auth = require('./src/auth')
 const AutoEncryptPromise = import('@small-tech/auto-encrypt')
 const { onShutdown } = require('node-graceful-shutdown')
 const morgan = require('morgan')
-const { debugOutput, parseHandle } = require('./src/utils')
+const { debugOutput, parseHandle, apexDomain } = require('./src/utils')
 const { apex, createImmersActor, deliverWelcomeMessage, routes, onInbox, onOutbox, outboxPost } = require('./src/apex')
 const { migrate } = require('./src/migrate')
 const { scopes } = require('./common/scopes')
@@ -96,6 +96,7 @@ const sessionStore = new MongoSessionStore({
   collection: 'sessions',
   maxAge: 365 * 24 * 60 * 60 * 1000
 })
+
 app.use(session({
   secret: sessionSecret,
   resave: true,
@@ -103,9 +104,12 @@ app.use(session({
   store: sessionStore,
   cookie: {
     maxAge: 365 * 24 * 60 * 60 * 1000,
-    secure: true
+    secure: true,
+    // allow logged in requests from both immer and hub
+    domain: apexDomain(domain)
   }
 }))
+console.log("cookie domain", apexDomain(domain))
 app.use(passport.initialize())
 app.use(passport.session())
 app.use(apex)

--- a/index.js
+++ b/index.js
@@ -109,7 +109,6 @@ app.use(session({
     domain: apexDomain(domain)
   }
 }))
-console.log("cookie domain", apexDomain(domain))
 app.use(passport.initialize())
 app.use(passport.session())
 app.use(apex)
@@ -138,8 +137,8 @@ app.route('/auth/login')
 app.get('/auth/home', auth.checkImmer)
 app.get('/auth/logout', auth.logout, (req, res) => res.redirect('/'))
 app.post('/auth/logout', auth.logout, (req, res) => {
-  return res.sendStatus(200);
-});
+  return res.sendStatus(200)
+})
 app.post('/auth/client', auth.registerClient)
 
 app.post('/auth/forgot', passport.authenticate('easy'), (req, res) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5407,6 +5407,11 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "ip-regex": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
+      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q=="
+    },
     "ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -5567,6 +5572,14 @@
       "integrity": "sha1-4E8cGNOUhRETlvmgJz6rUa8hhGQ=",
       "requires": {
         "html-tags": "^1.0.0"
+      }
+    },
+    "is-ip": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
+      "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
+      "requires": {
+        "ip-regex": "^4.0.0"
       }
     },
     "is-negative-zero": {
@@ -7129,6 +7142,16 @@
             "safer-buffer": "^2.1.0"
           }
         }
+      }
+    },
+    "parse-domain": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/parse-domain/-/parse-domain-4.1.0.tgz",
+      "integrity": "sha512-zas79foMEsbMbIcJoPx26+NISWa3jTzZykOW9mXfRzvgadHvAHGd7qcCc1FbSWbD1I4qP71UWAxlTgu7Uq6IQg==",
+      "requires": {
+        "is-ip": "^3.1.0",
+        "node-fetch": "^2.6.1",
+        "punycode": "^2.1.1"
       }
     },
     "parse-json": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "oauth2orize": "^1.11.0",
     "overlaps": "^1.0.0",
     "parcel-bundler": "^1.12.5",
+    "parse-domain": "^4.1.0",
     "passport": "^0.4.1",
     "passport-anonymous": "^1.0.1",
     "passport-http-bearer": "^1.0.1",

--- a/src/auth.js
+++ b/src/auth.js
@@ -323,7 +323,7 @@ module.exports = {
   priv,
   scope,
   localToken: [hubCors, localToken],
-  logout,
+  logout: [hubCors, logout],
   userToActor,
   registerUser,
   changePassword,

--- a/src/auth.js
+++ b/src/auth.js
@@ -320,7 +320,7 @@ module.exports = {
   publ,
   priv,
   scope,
-  localToken,
+  localToken: [hubCors, localToken],
   logout,
   userToActor,
   registerUser,

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,9 @@
+const { parseDomain, ParseResultType } = require('parse-domain')
+
 module.exports = {
   parseHandle,
-  debugOutput
+  debugOutput,
+  apexDomain
 }
 
 function debugOutput (app) {
@@ -22,5 +25,19 @@ function parseHandle (handle) {
       username: match[1],
       immer: match[2]
     }
+  }
+}
+
+function apexDomain (domain) {
+  try {
+    const url = new URL(`https://${domain}`)
+    // use url.hostname to strip port from domain
+    const parsedDomain = parseDomain(url.hostname)
+    return parsedDomain.type === ParseResultType.Listed
+      ? [parsedDomain.domain, ...parsedDomain.topLevelDomains].join('.')
+      : url.hostname
+  } catch (err) {
+    console.warn(`Unable to parse apex domain: ${err.message}`)
+    return domain
   }
 }


### PR DESCRIPTION
Attempts to set the login session cookie on the apex domain for the immer so it will be available across all subdomains.

Also works in localdev, making the cookie available for any port on localhost