### PR TITLE
upgrade autoencrypt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+**Urgent update**: Your SSL certificates may not be able to renew
+until you apply this update
+
+### Changed
+* Updated auto-encrypt dependency to fix error generating certificates.
+
 ## v3.3.2 (2022-08-26)
 
 **Includes migration**. Backup database before starting your server with this update.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1488,15 +1488,15 @@
       "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="
     },
     "@small-tech/auto-encrypt": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@small-tech/auto-encrypt/-/auto-encrypt-3.0.1.tgz",
-      "integrity": "sha512-5yhWkA5aCfTREJ7CKYJ8NuHF9x7I30M757XLRkpoX14cajkp1Rj2u6Jp2BYiKcw8s4pRURC2FC1a7qgRi0Vkyw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@small-tech/auto-encrypt/-/auto-encrypt-3.1.0.tgz",
+      "integrity": "sha512-adSJHdPERg9LJOHSpVz1GaBXQ3zGZLFezlzJgjRY+mvXE3RHlGamB4b0oR1cSyWwfjR9ZywNDAWAPyNWXov9hQ==",
       "requires": {
-        "bent": "bent@github:aral/bent#errors-with-response-headers",
+        "bent": "github:aral/bent#errors-with-response-headers",
         "encodeurl": "^1.0.2",
         "jose": "^1.24.0",
         "moment": "^2.24.0",
-        "node-forge": "^0.10.0",
+        "node-forge": "^1.3.1",
         "ocsp": "^1.2.0",
         "server-destroy": "^1.0.1"
       }
@@ -2478,7 +2478,7 @@
     "async": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+      "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -2610,8 +2610,8 @@
       }
     },
     "bent": {
-      "version": "github:aral/bent#errors-with-response-headers",
-      "from": "bent@github:aral/bent#errors-with-response-headers",
+      "version": "github:aral/bent#16a959683c6916204c28a1c870cb7b399c9215a9",
+      "from": "github:aral/bent#errors-with-response-headers",
       "requires": {
         "bytesish": "^0.4.1",
         "caseless": "~0.12.0",
@@ -5448,9 +5448,9 @@
       }
     },
     "jose": {
-      "version": "1.28.1",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-1.28.1.tgz",
-      "integrity": "sha512-6JK28rFu5ENp/yxMwM+iN7YeaInnY9B9Bggjkz5fuwLiJhbVrl2O4SJr65bdNBPl9y27fdC3Mymh+FVCvozLIg==",
+      "version": "1.28.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-1.28.2.tgz",
+      "integrity": "sha512-wWy51U2MXxYi3g8zk2lsQ8M6O1lartpkxuq1TYexzPKYLgHLZkCjklaATP36I5BUoWjF2sInB9U1Qf18fBZxNA==",
       "requires": {
         "@panva/asn1.js": "^1.0.0"
       }
@@ -6072,9 +6072,9 @@
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
     },
     "moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "mongo-escape": {
       "version": "2.0.6",
@@ -6227,9 +6227,9 @@
       "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
     },
     "node-graceful-shutdown": {
       "version": "1.1.0",
@@ -6471,7 +6471,7 @@
     "ocsp": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ocsp/-/ocsp-1.2.0.tgz",
-      "integrity": "sha1-RpoXdrRX3uZ+sCAUCMGUa6xAdsw=",
+      "integrity": "sha512-r4Q3oYKU+3b6iD4bn+5O2dQqctu8pFrJfWouUiKjiNXXjdr99lN/EaTVkFQevGlV/lKsomgtt/XRGB8xV8rq3Q==",
       "requires": {
         "asn1.js": "^4.8.0",
         "asn1.js-rfc2560": "^4.0.0",
@@ -7545,7 +7545,7 @@
     "server-destroy": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
-      "integrity": "sha1-8Tv5KOQrnD55OD5hzDmYtdFObN0="
+      "integrity": "sha512-rb+9B5YBIEzYcD6x2VKidaa+cqYBJQKnU4oe4E3ANwRRN56yk/ua1YCJT1n21NTS8w6CcOclAKNP3PhdCXKYtQ=="
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -7602,7 +7602,7 @@
     "simple-lru-cache": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz",
-      "integrity": "sha1-1ZzDoZPBpdAyD4Tucy9uRxPlEd0="
+      "integrity": "sha512-uEv/AFO0ADI7d99OHDmh1QfYzQk/izT1vCmu/riQfh7qjBVUUgRT87E5s5h7CxWCA/+YoZerykpEthzVrW3LIw=="
     },
     "smart-buffer": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/wmurphyrd/immers#readme",
   "dependencies": {
-    "@small-tech/auto-encrypt": "^3.0.1",
+    "@small-tech/auto-encrypt": "^3.1.0",
     "activitypub-express": "^3.3.0",
     "aesthetic-css": "^1.0.1",
     "bcrypt": "^5.0.1",


### PR DESCRIPTION
Discovered auto-encrypt could no longer get certs when deploying scores.chessboxing.space - the update fixed it but I think that means all immers instances are facing down cert expiration until this gets out