### PR TITLE
Controlled accounts login

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -20,3 +20,4 @@ proxyMode=
 enablePublicRegistration=true
 enableClientRegistration=true
 cookieName=connect.sid
+loginRedirect=

--- a/.env.defaults
+++ b/.env.defaults
@@ -19,3 +19,4 @@ welcome=
 proxyMode=
 enablePublicRegistration=true
 enableClientRegistration=true
+cookieName=connect.sid

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+### Added
+
+* Alternate version of `POST /auth/login` for controlled accounts that uses service account authentication instead of password
+[More info](./doc/ControlledAccounts.md)
+
 ## v3.4.0 (2022-09-16)
 
 **Urgent update**: Your SSL certificates may not be able to renew

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ### Added
 
-* Alternate version of `POST /auth/login` for controlled accounts that uses service account authentication instead of password
-[More info](./doc/ControlledAccounts.md)
+* Proxy logins: Enable users with controlled accounts to still use their portable
+identities throughout the metaverse.
+  * Alternate version of `POST /auth/login` for controlled accounts that uses service account authentication instead of password
+[More info](./doc/ControlledAccounts.md#logging-in-a-controlled-account)
+  * Configuration option to redirect to a custom login page for controlled accounts [More info](./doc/ControlledAccounts.md#custom-login-redirect)
 * Configuration option to alter session cookie id
 
 ## v3.4.0 (2022-09-16)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Alternate version of `POST /auth/login` for controlled accounts that uses service account authentication instead of password
 [More info](./doc/ControlledAccounts.md)
+* Configuration option to alter session cookie id
 
 ## v3.4.0 (2022-09-16)
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ keyPath, certPath, caPath | Local development only. Relative paths to certificat
 proxyMode | Enable use behind an SSL-terminating proxy or load balancer, serves over http instead of https and sets Express `trust proxy` setting to the value of `proxyMode` (e.g. `1`, [other options](https://expressjs.com/en/guide/behind-proxies.html)) | none (serves over https with AutoEncrypt)
 enablePublicRegistration | Allow new user self-registration | true
 enableClientRegistration | Allow new remote immers servers to register - if this is `false`, users will not be able to login with their accounts from other servers unless that server is already registered | true
+cookieName | Changes the key associated with session cookies, useful to differentiate sessions if you have multiple immers servers on the same apex domain | `connect.sid`
 
 **Notes on use with a reverse proxy**: When setting `proxyMode`, you must ensure your reverse proxy sets the following headers: X-Forwarded-For, X-Forwarded-Host, and X-Forwarded-Proto (example for nginx below). If you are load balancing multiple immers server instances, you will also need to setup sticky sessions in order for streaming updates to work. 
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ proxyMode | Enable use behind an SSL-terminating proxy or load balancer, serves 
 enablePublicRegistration | Allow new user self-registration | true
 enableClientRegistration | Allow new remote immers servers to register - if this is `false`, users will not be able to login with their accounts from other servers unless that server is already registered | true
 cookieName | Changes the key associated with session cookies, useful to differentiate sessions if you have multiple immers servers on the same apex domain | `connect.sid`
+loginRedirect | Replace the immers login experience with your custom page ([details](./doc/ControlledAccounts.md#custom-login-redirect)) | none
 
 **Notes on use with a reverse proxy**: When setting `proxyMode`, you must ensure your reverse proxy sets the following headers: X-Forwarded-For, X-Forwarded-Host, and X-Forwarded-Proto (example for nginx below). If you are load balancing multiple immers server instances, you will also need to setup sticky sessions in order for streaming updates to work. 
 

--- a/dev-utils/controlled-account-token.mjs
+++ b/dev-utils/controlled-account-token.mjs
@@ -30,7 +30,7 @@ await httpClient.post(
       assertion: oAuthJwt
     }).toString()
 ).then(response => {
-  const { accessToken, scope } = response.data
+  const { access_token: accessToken, scope } = response.data
   console.log(`access_token: ${accessToken}`)
   console.log(`scope: ${scope}`)
 }).catch((e) => {

--- a/doc/ControlledAccounts.md
+++ b/doc/ControlledAccounts.md
@@ -103,3 +103,71 @@ Send the token and scope back your client, and then use it to login to the Immer
 ```js
 const success = await immersClient.loginWithToken(access_token, "yourDomain.com", scope)
 ```
+
+## Logging in a controlled account
+
+For controlled accounts to be able to use their identities on other federated immers servers,
+users will need to be able to create a logged-in session. A simple option is to allow
+users to set a password after controlled account creation using the existing forgot password
+flow - this will work automatically as long as your config inluduces SMTP mail settings.
+For a more seamless experience, you can also log users in by using your service account credentials.
+
+**Requirements:**
+* Your application API server and your immers server must be on the same apex domain
+* If your application API server is not on the same origin as your web application, it must
+set CORS headers `Access-Control-Allow-Origin` (specific origin required, not just `*`), and
+`Access-Control-Allow-Credentials: true`
+* If your application API server is not on the same origin as your web application,
+the client side fetch must specify `credentials: include`
+
+### Server-side
+
+```js
+const { readFileSync } = require('fs')
+const jwt = require('jsonwebtoken')
+const cors = require("cors")
+const axios = require('axios') // any request library will do
+const immersAdminPrivateKey = readFileSync('immersAdminPrivateKey.pem')
+
+const proxyLogin = [
+  cors({
+    origin: 'https://hub.yourdomain.com', // make this match the origin of your web application
+    credentials: true
+  }),
+  yourUserAuthenticationMiddleware,
+  (req, res, next) => {
+    const oAuthJwt = jwt.sign(
+      {
+        scope: "*",
+        origin: "https://hub.yourDomain.com" // make this match the origin where the tokens will be used
+      },
+      immersAdminPrivateKey,
+      {
+        algorithm: "RS256",
+        issuer: `https://yourDomain.com/o/immer`,
+        audience: `https://yourDomain.com/o/immer`,
+        expiresIn: "1h",
+        subject: "user[yourdomain.dom]" // the authenticated user that you will login as
+      }
+    )
+    axios({
+      method: "post",
+      url: `https://yourDomain.com/auth/login`,
+      headers: { Authorization: `Bearer ${oAuthJwt}` }
+    }).then(response => {
+      // forward the login session cookie
+      res.set("Set-Cookie", response.headers["set-cookie"]);
+      res.sendStatus(200);
+    }).catch(next)
+  }
+]
+```
+
+### Client-side
+```js
+fetch('https://application-api-server.com/proxy-login', {
+  method: 'POST',
+  credentials: 'include',
+  // also include credentials necessary to authenticate this user
+})
+```

--- a/doc/ControlledAccounts.md
+++ b/doc/ControlledAccounts.md
@@ -171,3 +171,32 @@ fetch('https://application-api-server.com/proxy-login', {
   // also include credentials necessary to authenticate this user
 })
 ```
+
+### Custom login redirect
+
+While proxy-login above will allow users to seamlessly use
+their controlled account identities on other immers-enabled sites,
+in the off chance they attempt to use that identity in a browser
+where they haven't arleady completed a proxy login, you can
+customize the login experience they will see in that flow
+by redirecting to you app with the `loginRedirect` config setting.
+
+Set it to the url of your login experience,
+e.g. `loginRedirect=https://yourdomain.com/login`,
+and users will see this page instead of the Immers Server login page
+when a login is required to complete an authorization request.
+
+In your app's login flow, you must perform a proxy login as described
+above and check for a `redirectAfterLogin`
+query parameter on the login page and redirect there after a
+successful login.
+
+```
+// after successful login & proxy login
+const searchParams = new URLSearchParams(window.location.search);
+const redirect = searchParams.get("redirectAfterLogin");
+if (searchParams.has("redirectAfterLogin")) {
+  // return to interrupted OAuth authorization flow
+  window.location.href = searchParams.get("redirectAfterLogin");
+}
+```

--- a/index.js
+++ b/index.js
@@ -61,7 +61,8 @@ const {
   systemDisplayName,
   welcome,
   proxyMode,
-  enablePublicRegistration
+  enablePublicRegistration,
+  cookieName
 } = process.env
 let welcomeContent
 if (welcome && fs.existsSync(path.join(__dirname, 'static-ext', welcome))) {
@@ -114,6 +115,7 @@ app.use(session({
   resave: true,
   saveUninitialized: false,
   store: sessionStore,
+  name: cookieName,
   cookie: {
     maxAge: 365 * 24 * 60 * 60 * 1000,
     secure: true,

--- a/index.js
+++ b/index.js
@@ -142,6 +142,13 @@ app.use(express.urlencoded({ extended: false }))
 app.use(express.json({ type: ['application/json'].concat(apex.consts.jsonldTypes) }))
 
 /// auth related routes ///
+// route for getting a login session cookie with controlled accounts
+app.post(
+  '/auth/login',
+  auth.passIfNotAuthorized,
+  auth.controlledAccountLogin
+)
+// routes for normal user login
 app.route('/auth/login')
   .get((req, res) => {
     const data = Object.assign({}, renderConfig)
@@ -234,8 +241,7 @@ const register = [auth.validateNewUser, auth.logout, registerActor, auth.registe
 app.post(
   '/auth/user',
   auth.passIfNotAuthorized,
-  passport.authenticate('oauth2-client-jwt', { session: false }),
-  auth.requirePrivilege('canControlUserAccounts'),
+  auth.authorizeServiceAccount,
   register,
   auth.respondRedirect
 )

--- a/index.js
+++ b/index.js
@@ -62,7 +62,8 @@ const {
   welcome,
   proxyMode,
   enablePublicRegistration,
-  cookieName
+  cookieName,
+  loginRedirect
 } = process.env
 let welcomeContent
 if (welcome && fs.existsSync(path.join(__dirname, 'static-ext', welcome))) {
@@ -153,6 +154,14 @@ app.post(
 // routes for normal user login
 app.route('/auth/login')
   .get((req, res) => {
+    if (loginRedirect) {
+      const redirect = new URL(loginRedirect)
+      if (req.session?.returnTo) {
+        redirect.searchParams.set('redirectAfterLogin', `https://${domain}${req.session.returnTo}`)
+        delete req.session.returnTo
+      }
+      return res.redirect(redirect.href)
+    }
     const data = Object.assign({}, renderConfig)
     if (req.session && req.session.handle) {
       Object.assign(data, parseHandle(req.session.handle))

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -21,6 +21,8 @@ module.exports = {
   friendsScope: resourceServer.friendsScope,
   localToken: resourceServer.localToken,
   logout: resourceServer.logout,
+  authorizeServiceAccount: resourceServer.authorizeServiceAccount,
+  controlledAccountLogin: resourceServer.controlledAccountLogin,
   oidcLoginProviders: resourceServer.oidcLoginProviders,
   passIfNotAuthorized: resourceServer.passIfNotAuthorized,
   requirePrivilege: resourceServer.requirePrivilege,

--- a/src/auth/resourceServer.js
+++ b/src/auth/resourceServer.js
@@ -187,7 +187,7 @@ async function proxyLogin (req, res, next) {
   if (!user) {
     return res.sendStatus(404)
   }
-  if (!validatedPayload.scope === '*') {
+  if (validatedPayload.scope !== '*') {
     return res.status(403).send('insufficient scope')
   }
   // create a login session and set-cookie header

--- a/src/auth/resourceServer.js
+++ b/src/auth/resourceServer.js
@@ -39,6 +39,7 @@ const nameCheck = '^[A-Za-z0-9_~ -]{3,32}$'
 /// exports ///
 /** Dynamic CORS for logged-in users */
 const hubCors = cors(dynamicCorsFromToken)
+const clnt = passport.authenticate('oauth2-client-jwt', { session: false })
 module.exports = {
   /** auth for private routes only accessible with user access token (e.g. outbox POST) */
   priv: [passport.authenticate('bearer', { session: false }), hubCors],
@@ -47,7 +48,7 @@ module.exports = {
   /** like public but with wide-open CORS (user profile lookup from destinations) */
   open: [passport.authenticate(['bearer', 'anonymous'], { session: false }), cors()],
   /** auth for OAuth client / service account jwt login (e.g. in Authorization code grant) */
-  clnt: passport.authenticate('oauth2-client-jwt', { session: false }),
+  clnt,
   admn: [passport.authenticate('bearer', { session: false }), requireAdmin],
   scope,
   /** Require access to view private information */
@@ -58,6 +59,16 @@ module.exports = {
   localToken: [hubCors, localToken],
   /** terminate login session */
   logout: [hubCors, logout],
+  /** Check permission to control user */
+  authorizeServiceAccount: [
+    clnt,
+    requirePrivilege('canControlUserAccounts')
+  ],
+  /** Create login session for user via controlled account  */
+  controlledAccountLogin: [
+    clnt,
+    proxyLogin
+  ],
   oidcLoginProviders,
   /** for endpoints that behave differently for authorized requests */
   passIfNotAuthorized,
@@ -157,6 +168,35 @@ passport.use(new AnonymousStrategy())
 function logout (req, res, next) {
   req.logout()
   next()
+}
+/**
+ * Get a login session cookie for a controlled account,
+ * jwt `sub` claim contains handle
+ */
+async function proxyLogin (req, res, next) {
+  const client = req.user // set via oauth2-client-jwt authentication
+  // re-validate the jwt because control requires authorization in addition to authentication
+  const token = req.get('authorization')?.split('Bearer ')[1]
+  let user
+  let validatedPayload
+  try {
+    ({ user, validatedPayload } = await authdb.authorizeAccountControl(client, token))
+  } catch (err) {
+    next(err)
+  }
+  if (!user) {
+    return res.sendStatus(404)
+  }
+  if (!validatedPayload.scope === '*') {
+    return res.status(403).send('insufficient scope')
+  }
+  // create a login session and set-cookie header
+  req.login(user, (err) => {
+    if (err) {
+      return next(err)
+    }
+    res.sendStatus(200)
+  })
 }
 /** token grant for logged-in users in immers client */
 function localToken (req, res) {


### PR DESCRIPTION
Extends the controlled accounts feature to make those accounts still usable via immers login on other sites

- Automatically create a logged-in session & cookie via proxy-login
- Allow custom login page redirect as the immers login won't work for controlled users that have no password