### PR TITLE
pass returnTo url in relayState to ensure it survives potential sessi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Fixed
+
+* Fix SAML SSO intermittently not redirecting properly in Chrome, leaving popup open after login and failing to return token to opener
+
 ## v5.0.3 (2023-03-29)
 
 ### Fixed


### PR DESCRIPTION
…on reset

Note the `|` character added as a separator is not allowed in domain names so it shouldn't require additional validation on SSO setup