### PR TITLE
Username length and interstitial stuck

### DIFF
--- a/src/auth/oauthClient.js
+++ b/src/auth/oauthClient.js
@@ -356,6 +356,8 @@ function interpolateUsernameTemplate (client, ssoData) {
     .replace(/\{(\w+)\}/g, (_, key) => ssoData[key] ?? '')
     // strip any characters not allowed in username
     .replace(/[^A-Za-z0-9-]/g, '')
+    // limit to max username length
+    .substring(0, 32)
   console.log(
     'Generated username from template %s and data %j: %s',
     client.usernameTemplate,

--- a/views/components/HandleInput.js
+++ b/views/components/HandleInput.js
@@ -26,7 +26,7 @@ export default class HandleInput extends React.Component {
             id='username'
             type='text' inputMode='email' name='username'
             placeholder='username'
-            required pattern='^[A-Za-z0-9-]{3,32}$'
+            required pattern='[A-Za-z0-9\-]{3,32}'
             autoCapitalize='off' autoCorrect='off' spellCheck='false'
             title='Letters, numbers, &amp; dashes only, between 3 and 32 characters'
             value={this.state.username}

--- a/views/oidc-interstitial/oidc-interstitial.js
+++ b/views/oidc-interstitial/oidc-interstitial.js
@@ -91,7 +91,7 @@ function RegisterForm ({ domain, fetching, setFetching }) {
   }, [setFetching, setTakenMessage, setRegistrationError, setRegistrationSuccess])
   useEffect(() => {
     // auto-submit form when page loads if username prefilled
-    if (proposedUsername && formEl.reportValidity()) {
+    if (proposedUsername && formEl.current.reportValidity()) {
       formEl.current.dispatchEvent(
         new Event('submit', { bubbles: true, cancelable: true })
       )

--- a/views/oidc-interstitial/oidc-interstitial.js
+++ b/views/oidc-interstitial/oidc-interstitial.js
@@ -91,7 +91,7 @@ function RegisterForm ({ domain, fetching, setFetching }) {
   }, [setFetching, setTakenMessage, setRegistrationError, setRegistrationSuccess])
   useEffect(() => {
     // auto-submit form when page loads if username prefilled
-    if (proposedUsername) {
+    if (proposedUsername && formEl.reportValidity()) {
       formEl.current.dispatchEvent(
         new Event('submit', { bubbles: true, cancelable: true })
       )


### PR DESCRIPTION
Trim auto-generated usernames to max length. Check form validity before attempting to auto-submit username to avoid triggering invalid SSO state handling on front end that locks out further form submissions